### PR TITLE
Introduce ReactNative Island

### DIFF
--- a/ReactNativeIsland.cpp
+++ b/ReactNativeIsland.cpp
@@ -1,0 +1,113 @@
+#include "pch.h"
+#include "ReactNativeIsland.h"
+#include "ReactNativeIsland.g.cpp"
+#include <winrt/Microsoft.UI.Interop.h>
+
+namespace winrt::ReactNative
+{
+    using namespace winrt::Microsoft::ReactNative;
+    using namespace winrt::Microsoft::ReactNative::Composition;
+}
+
+namespace winrt::UI
+{
+    using namespace winrt::Microsoft::UI::Composition;
+    using namespace winrt::Microsoft::UI::Content;
+    using namespace winrt::Microsoft::UI::Input;
+    using namespace winrt::Microsoft::UI::Windowing;
+}
+
+float ScaleFactor(HWND hwnd) noexcept {
+    return GetDpiForWindow(hwnd) / static_cast<float>(USER_DEFAULT_SCREEN_DPI);
+}
+
+namespace winrt::Microsoft::ReactNative::implementation
+{
+    winrt::ReactNative::ReactNativeIsland ReactNativeIsland::Create(
+        winrt::UI::Compositor const& compositor,
+        winrt::UI::AppWindow const& window,
+        winrt::ReactNative::ReactNativeHost const& host,
+        winrt::hstring const& mainComponentName)
+    {
+        return winrt::make<ReactNativeIsland>(compositor, window, host, mainComponentName);
+    }
+
+    ReactNativeIsland::~ReactNativeIsland()
+    {
+        // Does the CompositionRootView close the Island? Or do we close the island independently?
+        m_island.Close();
+    }
+
+    void ReactNativeIsland::SetScaleFactor(winrt::UI::AppWindow const& window)
+    {
+        auto hwnd = winrt::Microsoft::UI::GetWindowFromWindowId(window.Id());
+        m_scaleFactor = ScaleFactor(hwnd);
+    }
+
+    ReactNativeIsland::ReactNativeIsland(
+        winrt::UI::Compositor const& compositor,
+        winrt::UI::AppWindow const& window,
+        winrt::ReactNative::ReactNativeHost const& host,
+        winrt::hstring const& mainComponentName)
+        : m_compositor(compositor)
+    {
+        SetScaleFactor(window);
+
+        winrt::ReactNative::ReactViewOptions viewOptions;
+        viewOptions.ComponentName(mainComponentName);
+
+        // Create a RootView (creates a spriteVisual) and associates it with an island
+        m_rootView = winrt::ReactNative::CompositionRootView(m_compositor);
+        m_rootView.ReactViewHost(
+            winrt::ReactNative::ReactCoreInjection::MakeViewHost(host, viewOptions));
+
+        // Create a contentIsland
+        m_island = m_rootView.Island();
+
+        auto invScale = 1.0f / m_scaleFactor;
+        m_rootView.RootVisual().Scale({ invScale, invScale, invScale });
+        m_rootView.ScaleFactor(m_scaleFactor);
+
+        // Set the intialSize of the root view
+        UpdateRootViewSizeToAppWindow(window);
+
+        // Lifted input base setup.
+        m_mouseInput = winrt::UI::InputPointerSource::GetForIsland(m_island);
+        m_keyboardInput = winrt::UI::InputKeyboardSource::GetForIsland(m_island);
+    }
+
+    void ReactNativeIsland::InitalizeInputHandlers()
+    {
+        m_mouseInput.PointerPressed([this](auto& /*sender*/, auto&args) {
+            if (args.CurrentPoint().Properties().IsLeftButtonPressed())
+            {
+                /* Implement here */
+                args.Handled(true);
+            }
+            else if (args.CurrentPoint().Properties().IsRightButtonPressed())
+            {
+                /* Implement here */
+                args.Handled(true);
+            }
+        });
+
+        // Implementing just one key for example
+        m_keyboardInput.KeyUp([this](auto& /*sender*/, auto&args) {
+            /* Implement here */
+        });
+    }
+
+    void ReactNativeIsland::UpdateRootViewSizeToAppWindow(
+        winrt::Microsoft::UI::Windowing::AppWindow const& window) {
+
+        winrt::Windows::Foundation::Size size{
+            window.ClientSize().Width / m_scaleFactor, window.ClientSize().Height / m_scaleFactor };
+
+        // Do not relayout when minimized
+        if (window.Presenter().as<winrt::UI::OverlappedPresenter>().State() !=
+            winrt::UI::OverlappedPresenterState::Minimized) {
+            m_rootView.Arrange(size);
+            m_rootView.Size(size);
+        }
+    }
+}

--- a/ReactNativeIsland.h
+++ b/ReactNativeIsland.h
@@ -1,0 +1,54 @@
+#pragma once
+#include "ReactNativeIsland.g.h"
+
+namespace winrt::Microsoft::ReactNative::implementation
+{
+    struct ReactNativeIsland : ReactNativeIslandT<ReactNativeIsland>
+    {
+        ReactNativeIsland() = default;
+
+        ReactNativeIsland(
+            const winrt::Microsoft::UI::Composition::Compositor& compositor,
+            winrt::Microsoft::UI::Windowing::AppWindow const& window,
+            winrt::Microsoft::ReactNative::ReactNativeHost const& host,
+            winrt::hstring const& mainComponentName);
+
+        ~ReactNativeIsland();
+
+        static winrt::Microsoft::ReactNative::ReactNativeIsland Create(
+            winrt::Microsoft::UI::Composition::Compositor const& compositor,
+            winrt::Microsoft::UI::Windowing::AppWindow const& window,
+            winrt::Microsoft::ReactNative::ReactNativeHost const& host,
+            winrt::hstring const& mainComponentName);
+
+	    winrt::Microsoft::UI::Content::ContentIsland Island() const
+        {
+            return m_island;
+        }
+
+        void UpdateRootViewSizeToAppWindow(
+            winrt::Microsoft::UI::Windowing::AppWindow const& window);
+
+	private:
+        void SetScaleFactor(winrt::Microsoft::UI::Windowing::AppWindow const& window);
+
+        // Initialize Mouse and Keyboard input handlers
+        void InitalizeInputHandlers();
+
+		winrt::Microsoft::UI::Composition::Compositor m_compositor{nullptr};
+		winrt::Microsoft::ReactNative::CompositionRootView m_rootView { nullptr };
+		winrt::Microsoft::UI::Content::ContentIsland m_island{ nullptr };
+
+        float m_scaleFactor{ 0 };
+
+        // Input objects.
+        winrt::Microsoft::UI::Input::InputPointerSource m_mouseInput{ nullptr };
+        winrt::Microsoft::UI::Input::InputKeyboardSource m_keyboardInput{ nullptr };
+    };
+}
+namespace winrt::Microsoft::ReactNative::factory_implementation
+{
+    struct ReactNativeIsland : ReactNativeIslandT<ReactNativeIsland, implementation::ReactNativeIsland>
+    {
+    };
+}

--- a/ReactNativeIsland.idl
+++ b/ReactNativeIsland.idl
@@ -1,0 +1,29 @@
+
+import "CompositionSwitcher.idl";
+import "CompositionRootView.idl";
+import "ReactNativeHost.idl";
+
+namespace Microsoft.ReactNative
+{
+#ifdef USE_WINUI3
+	runtimeclass ReactNativeIsland
+	{
+		// Create the ReactNativeIsland which sets up the contentIsland and the
+		// CompositionRootView
+		// This Island makes the assumption that we have:
+		// One ReactNativeHost that is mapped to one JSBundle with one JsApp(rootview) in the bundle.
+		static ReactNativeIsland Create(
+			Microsoft.UI.Composition.Compositor compositor,
+			Microsoft.UI.Windowing.AppWindow window,
+			Microsoft.ReactNative.ReactNativeHost host,
+			String mainComponentName);
+
+		// Each RNIsland has one ContentIsland and the ContentIsland is associated to single JsApp.
+		Microsoft.UI.Content.ContentIsland Island{ get; };
+
+		// Updates Root view size with respect to AppWindow size change
+		void UpdateRootViewSizeToAppWindow(
+			Microsoft.UI.Windowing.AppWindow window);
+	}
+#endif
+}


### PR DESCRIPTION
Introduce a ReactNative Island to make it easy for the native apps to host ReactNative content. ReactNative Island does the following:

1. Associate the CompositionRootView to a content Island. Each CompositionRootView is associated with a single JsApp in a JsBundle.
2. Set up the mouse and keyboard input source so that the Child Hwnd can receive and handle the input accordingly.
3. Updates the Rootview size based on size change on the AppWindow.

Future update: Move ReactNativeHost into the Island.